### PR TITLE
preserve mtime when copying artifacts

### DIFF
--- a/src/hatch_meson/plugin.py
+++ b/src/hatch_meson/plugin.py
@@ -410,7 +410,9 @@ class MesonBuildHook(BuildHookInterface):
 
             dst.parent.mkdir(parents=True, exist_ok=True)
 
-            shutil.copy(src, dst)
+            # Use copy2 to preserve file mtime, which ensures incremental build works
+            # if another project is consuming these files
+            shutil.copy2(src, dst)
 
         tag = _compute_tag(install_plan, self._limited_api)
 

--- a/src/hatch_meson/plugin.py
+++ b/src/hatch_meson/plugin.py
@@ -97,7 +97,7 @@ _INSTALLATION_PATH_MAP = {
 
 
 def _map_to_wheel(
-    sources: T.Dict[str, T.Dict[str, T.Any]]
+    sources: T.Dict[str, T.Dict[str, T.Any]],
 ) -> T.DefaultDict[str, T.List[T.Tuple[pathlib.Path, str]]]:
     """Map files to the wheel, organized by wheel installation directory."""
     wheel_files: T.DefaultDict[str, T.List[T.Tuple[pathlib.Path, str]]] = (
@@ -186,7 +186,7 @@ def _is_native(fname) -> bool:
 
 
 def _install_is_pure(
-    install_plan: T.DefaultDict[str, T.List[T.Tuple[pathlib.Path, str]]]
+    install_plan: T.DefaultDict[str, T.List[T.Tuple[pathlib.Path, str]]],
 ) -> bool:
     """Whether the wheel is architecture independent"""
     if install_plan["platlib"]:

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -16,15 +16,20 @@ def test_dynamic_version(sdist_dynamic_version):
     with tarfile.open(sdist_dynamic_version, "r:gz") as sdist:
         sdist_pkg_info = sdist.extractfile("dynamic_version-1.0.0/PKG-INFO").read()
 
-    assert metadata(sdist_pkg_info) == metadata(
+    sdist_metadata = metadata(sdist_pkg_info)
+    metadata_version = sdist_metadata.get("metadata_version", "2.3")
+
+    expected_metadata = metadata(
         textwrap.dedent(
-            """\
-            Metadata-Version: 2.3
+            f"""\
+            Metadata-Version: {metadata_version}
             Name: dynamic-version
             Version: 1.0.0
         """
         )
     )
+
+    assert sdist_metadata == expected_metadata
 
 
 # def test_contents(sdist_library):


### PR DESCRIPTION
- Ensures incremental build works when using in editable mode and another project is consuming the build output